### PR TITLE
Don't ignore filenames with dashes.

### DIFF
--- a/rsdioctl.cpp
+++ b/rsdioctl.cpp
@@ -136,7 +136,7 @@ int main(int argc, char *argv[])
 		}
 		else if (arg == "-h" || arg == "--human-readable")
 			human = true;
-		else if (arg.find("-") != arg.npos)
+		else if (arg.find("-") == 0)
 			ignoredArgs.emplace_back(arg);
 		else
 			argList.emplace_back(arg);

--- a/rspoectl.cpp
+++ b/rspoectl.cpp
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
 		}
 		else if (arg == "-h" || arg == "--human-readable")
 			human = true;
-		else if (arg.find("-") != arg.npos)
+		else if (arg.find("-") == 0)
 			ignoredArgs.emplace_back(arg);
 		else
 			argList.emplace_back(arg);


### PR DESCRIPTION
The current argument parser attempts to ignore any unknown arguments which include dashes (`-`). 
Unfortunately, that means that it also ignores xml filepath arguments with a dash in them.

This changes the parsers to only ignore unrecognized arguments if they have leading dashes.
